### PR TITLE
github: Don't run `shiroa build` in cron workflow

### DIFF
--- a/.github/workflows/upstream-check.yml
+++ b/.github/workflows/upstream-check.yml
@@ -4,6 +4,8 @@ on:
   schedule:
   - cron: '0 * * * *'
 
+  workflow_dispatch:
+
 defaults:
   run:
     shell: bash
@@ -46,6 +48,3 @@ jobs:
 
       - name: Run `shiroa --version`
         run: shiroa --version
-
-      - name: Run `shiroa build`
-        run: shiroa build test/book


### PR DESCRIPTION
New releases may contain changes to the API that we can't foresee, whcih may result in false negatives of this check. This check should only ensure that we can pull the newest version successfully, CI ensures that such versions are also runnable.