### PR TITLE
just: Run `check` before `update`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -28,9 +28,8 @@ check: install
 	@npm run lint
 
 # Update the compiled action in dist (for releases)
-update: clean install
-	@echo "{{prompt}} Updating "
-	@npm run build
+update: clean install check
+	@echo "{{prompt}} Updating dist"
 	@rm --recursive --force {{ root / 'dist' }}
 	@cp --recursive {{ root / 'build ' }} {{ root / 'dist' }}
 


### PR DESCRIPTION
The extra `npm run build` was also redundant since we run a clean install beforehand.